### PR TITLE
Added shebang to run as script and added help output if no args presented

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ Usage
 .. code-block:: bash
 
    # pipe the output from calling the script with some names to a file
-   python3 create_latex.py Alice Bob Charlie > badges.tex
+   ./create_latex.py Alice Bob Charlie > badges.tex
 
    # ... or you can specify a size in mm
-   python3 create_latex.py 58 Alice Bob Charlie > badges.tex
+   ./create_latex.py 58 Alice Bob Charlie > badges.tex
 
    # build the file with pdflatex
    pdflatex badges

--- a/create_latex.py
+++ b/create_latex.py
@@ -1,6 +1,13 @@
+#!/usr/bin/env python3
+
 import sys
 
 names = sys.argv[1:]
+
+if len(sys.argv) == 1:
+    # Print usage
+    print("Usage: create_latex.py [<size>] <name> [<name> ...] > <output.tex>")
+    exit(1)
 
 # Hacky way of providing a size input
 try:
@@ -43,4 +50,6 @@ print(header)
 for name in names:
     print(badge_entry(name))
 print(footer)
+
+
 


### PR DESCRIPTION
I've added 2 things to the script.

First, added `#!/usr/bin/env python3` so that the script can be called without the need of `python3 create_latex.py ...`

Second, running the script with no args will output some simple help.


I've also updated the `README.rst` to show running it with `./create_latex.py ....` 
